### PR TITLE
Enable/disable engine selection based on checkbox

### DIFF
--- a/SAFEFINAL.py
+++ b/SAFEFINAL.py
@@ -734,6 +734,7 @@ class TabValidate(QWidget):
         self.cmb_engine = QComboBox()
         self.cmb_engine.addItems(ENGINE_NAMES)
         self.chk_use_all_engines = QCheckBox("Use ALL Engines")
+        self.chk_use_all_engines.toggled.connect(self.on_use_all_engines_toggled)
         engine_row.addWidget(QLabel("Engine:"))
         engine_row.addWidget(self.cmb_engine)
         engine_row.addStretch(1)
@@ -870,6 +871,9 @@ class TabValidate(QWidget):
         self.cmb_filter_result.setCurrentIndex(0)
         self.cmb_filter_engine.setCurrentIndex(0)
         self.txt_filter_search.clear()
+
+    def on_use_all_engines_toggled(self, checked):
+        self.cmb_engine.setEnabled(not checked)
 
     def browse_ipfile(self):
         path, _ = QFileDialog.getOpenFileName(self, "Select IP:Port file", ".", "Text Files (*.txt);;All Files (*)")


### PR DESCRIPTION
Disable the Engine dropdown when the "Use ALL Engines" checkbox is checked to improve user experience in the Brute Force section.

---
<a href="https://cursor.com/background-agent?bcId=bc-95f16e73-30f6-45df-b6df-7d5ba567103f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-95f16e73-30f6-45df-b6df-7d5ba567103f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

