### PR TITLE
Enable/disable engine selection based on checkbox

### DIFF
--- a/SAFEFINAL.py
+++ b/SAFEFINAL.py
@@ -826,6 +826,7 @@ class TabValidate(QWidget):
         self.btn_resume.clicked.connect(self.resume)
         self.btn_stop.clicked.connect(self.stop)
         self.btn_reveal.clicked.connect(self.reveal_selected)
+        self.chk_use_all_engines.toggled.connect(self.on_use_all_engines_toggled)
 
         self.cmb_filter_result.currentIndexChanged.connect(self.apply_filters)
         self.cmb_filter_engine.currentIndexChanged.connect(self.apply_filters)
@@ -840,6 +841,7 @@ class TabValidate(QWidget):
 
         self._set_btn_states(running=False, paused=False)
         self.update_engine_status()
+        self.on_use_all_engines_toggled(self.chk_use_all_engines.isChecked())
 
     def _colorize(self, btn: QPushButton, bg: str, fg: str = "white"):
         btn.setStyleSheet(f"QPushButton {{ background: {bg}; color: {fg}; padding:6px 12px; border-radius:6px; }}"
@@ -1111,6 +1113,9 @@ class TabValidate(QWidget):
             self.bus.status.emit("Credentials saved to disk")
         except Exception as e:
             QMessageBox.warning(self, "Save error", f"Could not save revealed credential: {e}")
+
+    def on_use_all_engines_toggled(self, checked):
+        self.cmb_engine.setEnabled(not checked)
 
     def update_engine_status(self):
         states = detect_engines()


### PR DESCRIPTION
Connect "Use ALL Engines" checkbox to enable/disable the Engine selection menu to improve UX.

---
<a href="https://cursor.com/background-agent?bcId=bc-719e1af4-d6d5-45ac-ae2b-95a77b25b132">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-719e1af4-d6d5-45ac-ae2b-95a77b25b132">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

